### PR TITLE
Couple of edge cases are handled wrong

### DIFF
--- a/src/file-qoi.c
+++ b/src/file-qoi.c
@@ -277,7 +277,7 @@ fail_without_file:
 			guint8 run = (tag & 0x3F) + 1;
 
 			// Make sure there is enough space for all of the encoded pixels
-			if (pixel_index > max_pixel_index + run) {
+			if (pixel_index + run > max_pixel_index) {
 				g_message("Too many encoded pixels.");
 				g_free(result->pixels);
 				g_free(file_data);

--- a/src/file-qoi.c
+++ b/src/file-qoi.c
@@ -222,6 +222,7 @@ fail_without_file:
 
 			result->pixels[pixel_index++] = current_pixel;
 			array[qoi_pixel_hash(current_pixel)] = current_pixel;
+			++column_index;
 		} else if (tag == QOI_OP_RGBA) {
 			current_pixel.red   = file_data[file_index++];
 			current_pixel.green = file_data[file_index++];

--- a/src/file-qoi.c
+++ b/src/file-qoi.c
@@ -284,12 +284,11 @@ fail_without_file:
 				return false;
 			}
 
-			// As this is a repeat of the previous pixel, there is no need to
-			// update the map of previously used pixels, it's already there.
 			while (run-- != 0) {
 				result->pixels[pixel_index++] = current_pixel;
 				++column_index;
 			}
+			array[qoi_pixel_hash(current_pixel)] = current_pixel;
 		}
 
 		if (column_index >= result->width) {
@@ -381,6 +380,7 @@ static bool save_image(QoiImage image, const gchar *filename) {
 					run = 0;
 				}
 			}
+			array[hash] = current_pixel;
 		} else if (qoi_pixel_equal(current_pixel, array[hash])) {
 			file_data[file_index++] = QOI_OP_INDEX | hash;
 			previous_pixel = current_pixel;


### PR DESCRIPTION
I looked a bit through the code of this plugin (extremely readable btw :) ) and found a bug and couple things which are weird (note though that I don't have any experience writing GIMP plugins and haven't programmed in C for a long time, so I might wrongly think that something is wrong even though it's correct):

* The only bug I'm certain about is that a QOI_OP_RUN doesn't cause an update of the array, because it looks like the array was already updated when the last pixel was processed.  But this isn't true when the first pixel is \#000000FF, because the previous pixel is initialized with \#000000FF, but the array is with \#00000000.  The issue is well-known: phoboslab/qoi#258
* I'm not entirely sure whether maybe I am the one confusing something, but I think the `pixel_index > max_pixel_index + run` in line 280 should be `pixel_index + run > max_pixel_index`.
* In the read implementation there appears to be an `++column_index;` missing in the QOI_OP_RGB section.
* The variable name `max_pixel_index` is technically speaking wrong, because what it actually stores is the length of the pixel array and the last (i.e. maximal) index is of course one less.  (I know this is extremely nitpicky, but if I'm already unnecessarily complaining I can at least be thorough.)
* The `dr_db` variable which stores the values for `dr` and `db` look like the `dr_dg` and `db_dg` of the standard, but is completely different. (again: extremely nitpicky)
* That's probably just because I don't know C/GIMP, but the QOI_COLORSPACE_COUNT variant of the enum QoiColorspace seems to be unused.